### PR TITLE
add a test step to upload artifacts after merges

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,5 +37,6 @@ jobs:
           go-version: 1.15
       - run: go build
       - uses: actions/upload-artifact@v2
-        name: build-output $GITHUB_SHA
-        path: ./cdwebapp
+        with:
+          name: build-output $GITHUB_SHA
+          path: ./cdwebapp


### PR DESCRIPTION
This will be used to share the binary between subsequent build steps